### PR TITLE
fix some imports in tests, fix relative imports for python3

### DIFF
--- a/coclust/coclustering/__init__.py
+++ b/coclust/coclustering/__init__.py
@@ -8,8 +8,8 @@ algorithms.
 from .coclust_info import CoclustInfo
 from .coclust_mod import CoclustMod
 from .coclust_spec_mod import CoclustSpecMod
-from base_diagonal_coclust import BaseDiagonalCoclust
-from base_non_diagonal_coclust import BaseNonDiagonalCoclust
+from .base_diagonal_coclust import BaseDiagonalCoclust
+from .base_non_diagonal_coclust import BaseNonDiagonalCoclust
 
 __all__ = ['CoclustInfo',
            'CoclustMod',

--- a/tests/test_coclust.py
+++ b/tests/test_coclust.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.io import loadmat
 import sys
 
-from coclust.coclustering.CoclustMod import CoclustMod
+from coclust.coclustering import CoclustMod
 
 
 class TestDiagonal(TestCase):

--- a/tests/test_coclust_info.py
+++ b/tests/test_coclust_info.py
@@ -12,7 +12,7 @@ from scipy.io import loadmat
 import sys
 
 
-from coclust.coclustering.CoclustInfo import CoclustInfo
+from coclust.coclustering import CoclustInfo
 
 
 class TestCstr(TestCase):


### PR DESCRIPTION
I was trying to make the tests run.
Here are some minor fixes, but I still get the following errors:

```
======================================================================
ERROR: test suite for <class 'tests.test_coclust_info.TestClassic3'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 210, in run
    self.setUp()
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 293, in setUp
    self.setupContext(ancestor)
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 316, in setupContext
    try_run(context, names)
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/andy/checkout/cclust_package/tests/test_coclust_info.py", line 60, in setUpClass
    model.fit(X)
  File "/home/andy/checkout/cclust_package/coclust/coclustering/coclust_info.py", line 103, in fit
    self._fit_single(X, y)
  File "/home/andy/checkout/cclust_package/coclust/coclustering/coclust_info.py", line 181, in _fit_single
    delta_kl[delta_kl == 0.] = 0.0001  # to prevent log(0)
TypeError: 'coo_matrix' object does not support item assignment

======================================================================
ERROR: test suite for <class 'tests.test_coclust_info.TestCstr'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 210, in run
    self.setUp()
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 293, in setUp
    self.setupContext(ancestor)
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 316, in setupContext
    try_run(context, names)
  File "/home/andy/anaconda3/lib/python3.5/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/andy/checkout/cclust_package/tests/test_coclust_info.py", line 25, in setUpClass
    model.fit(X)
  File "/home/andy/checkout/cclust_package/coclust/coclustering/coclust_info.py", line 103, in fit
    self._fit_single(X, y)
  File "/home/andy/checkout/cclust_package/coclust/coclustering/coclust_info.py", line 181, in _fit_single
    delta_kl[delta_kl == 0.] = 0.0001  # to prevent log(0)
TypeError: 'coo_matrix' object does not support item assignment

```