### PR TITLE
Remove "warn_on_dtype" from check_array 

### DIFF
--- a/coclust/coclustering/coclust_fuzzy_mod.py
+++ b/coclust/coclustering/coclust_fuzzy_mod.py
@@ -89,8 +89,7 @@ class CoclustFuzzyMod(BaseDiagonalCoclust):
         check_array(X, accept_sparse=True, dtype="numeric", order=None,
                     copy=False, force_all_finite=True, ensure_2d=True,
                     allow_nd=False, ensure_min_samples=self.n_clusters,
-                    ensure_min_features=self.n_clusters,
-                    warn_on_dtype=False, estimator=None)
+                    ensure_min_features=self.n_clusters, estimator=None)
         
         if type(X) == np.ndarray:
             X = np.matrix(X)

--- a/coclust/coclustering/coclust_info.py
+++ b/coclust/coclustering/coclust_info.py
@@ -92,8 +92,7 @@ class CoclustInfo(BaseNonDiagonalCoclust):
         check_array(X, accept_sparse=True, dtype="numeric", order=None,
                     copy=False, force_all_finite=True, ensure_2d=True,
                     allow_nd=False, ensure_min_samples=self.n_row_clusters,
-                    ensure_min_features=self.n_col_clusters,
-                    warn_on_dtype=False, estimator=None)
+                    ensure_min_features=self.n_col_clusters, estimator=None)
 
         check_positive(X)
 

--- a/coclust/coclustering/coclust_mod.py
+++ b/coclust/coclustering/coclust_mod.py
@@ -159,8 +159,7 @@ class CoclustMod(BaseDiagonalCoclust):
         check_array(X, accept_sparse=True, dtype="numeric", order=None,
                     copy=False, force_all_finite=True, ensure_2d=True,
                     allow_nd=False, ensure_min_samples=self.n_clusters,
-                    ensure_min_features=self.n_clusters,
-                    warn_on_dtype=False, estimator=None)
+                    ensure_min_features=self.n_clusters, estimator=None)
 
         if type(X) == np.ndarray:
             X = np.matrix(X)

--- a/coclust/coclustering/coclust_plbcem.py
+++ b/coclust/coclustering/coclust_plbcem.py
@@ -86,8 +86,7 @@ class CoclustPLBcem:
         check_array(X, accept_sparse=True, dtype="numeric", order=None,
                     copy=False, force_all_finite=True, ensure_2d=True,
                     allow_nd=False, ensure_min_samples=self.n_row_clusters,
-                    ensure_min_features=self.n_col_clusters,
-                    warn_on_dtype=False, estimator=None)
+                    ensure_min_features=self.n_col_clusters, estimator=None)
 
         check_positive(X)
 

--- a/coclust/coclustering/coclust_spec_mod.py
+++ b/coclust/coclustering/coclust_spec_mod.py
@@ -83,8 +83,7 @@ class CoclustSpecMod(BaseDiagonalCoclust):
         check_array(X, accept_sparse=True, dtype="numeric", order=None,
                     copy=False, force_all_finite=True, ensure_2d=True,
                     allow_nd=False, ensure_min_samples=self.n_clusters + 1,
-                    ensure_min_features=self.n_clusters + 1,
-                    warn_on_dtype=False, estimator=None)
+                    ensure_min_features=self.n_clusters + 1, estimator=None)
 
         check_positive(X)
 


### PR DESCRIPTION
Changes made:

- remove "warn_on_dtype=false" in all file containing a check_array function from sklearn.utils package

Until now it "only" produced a FutureWarning but since version 0.23 it have been removed and now throws an error.