### PR TITLE
Problem with external evaluation module

### DIFF
--- a/coclust/clustering/spherical_kmeans.py
+++ b/coclust/clustering/spherical_kmeans.py
@@ -159,6 +159,7 @@ class SphericalKmeans:
 
             # hard assignment
             #Z=centers*X.T
+            # Prepare to migrate to scipy 0.19 so as to use argmax with csr matrix
             Z1 = X * centers.T
             Z1 = Z1.todense()
             Z1 = np.array(Z1)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ The :doc:`script<scripts>` enables the user to process a dataset with
 co-clustering algorithms without writing Python code.
 
 The Python package provides an :doc:`API<api/index>` for Python developers.
-This API allows to use the algorithms in a pipeline with scikit-learn library
+This API allows to use the algorithms in a pipeline with the scikit-learn library
 for example.
 
 **coclust** is distributed under the 3-Clause BSD license.


### PR DESCRIPTION
The error that occurs
Traceback (most recent call last):
    from coclust.evaluation.external import accuracy
  File "\venv\lib\site-packages\coclust\evaluation\external.py", line 12, in <module>
    from sklearn.utils.linear_assignment_ import linear_assignment
ModuleNotFoundError: No module named 'sklearn.utils.linear_assignment_'